### PR TITLE
WIP update motherduck wasm-client and vgplot

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,11 +2,15 @@ import { MDConnection } from "@motherduck/wasm-client";
 import * as vg from "@uwdata/vgplot";
 import { token } from "./token.js";
 import * as arrow from "apache-arrow";
+import * as flechette from "@uwdata/flechette";
 
 async function arrowTableFromResult(result) {
   if (result.type === "streaming") {
     const batches = await result.arrowStream.readAll();
-    return new arrow.Table(batches);
+    // very bad:
+    const old = new arrow.Table(batches)
+    const data = arrow.tableToIPC(old);
+    return new flechette.tableFromIPC(data)
   }
   throw Error("expected streaming result");
 }
@@ -38,7 +42,7 @@ const app = document.querySelector("#app");
 
 vg.coordinator().databaseConnector(connector);
 
-const table = "s.main.gaia_sample_1_percent_projected"
+const table = "my_db.main.gaia_projected_small" // todo document making this table "s.main.gaia_sample_1_percent_projected"
 
 const size = await connector.query({ sql: `SELECT COUNT(*) as cnt FROM ${table.split(".").map(s => `"${s}"`).join(".")}`, type: "arrow" })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@motherduck/wasm-client": "^0.4.0",
-        "@uwdata/vgplot": "^0.7.0"
+        "@motherduck/wasm-client": "^0.6.0",
+        "@uwdata/flechette": "^1.1.0",
+        "@uwdata/vgplot": "^0.11.0"
       },
       "devDependencies": {
         "vite": "^5.1.6"
@@ -37,11 +38,11 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.28.1-dev99.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.28.1-dev99.0.tgz",
-      "integrity": "sha512-EgIRjUFAos4oT4QeFLK6g7IDPWFWu8dP/mj2/b0pyiN5dDL+xxKW2KyLbeAs26L6Y6yeYy0O4OJSezFOqTbOmg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.0.tgz",
+      "integrity": "sha512-8Zq7vafQuIz9gklC/9375KE38UlkaS2n8+yvG+/JK7irm3DjwYNJHL4xfplIj0bSHFIg6we5XhWYFqtE/vO3+Q==",
       "dependencies": {
-        "apache-arrow": "^14.0.1"
+        "apache-arrow": "^17.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -413,17 +414,17 @@
       }
     },
     "node_modules/@motherduck/wasm-client": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@motherduck/wasm-client/-/wasm-client-0.4.0.tgz",
-      "integrity": "sha512-NNzs/DUQOpVZPCthbO3ka8PCdfBQN7cJXpNr+7kGbnJRqDaA/4Tpc99M5yl8wOKrYGwCZO36hIwe1+e+nRs8zQ==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@motherduck/wasm-client/-/wasm-client-0.6.6.tgz",
+      "integrity": "sha512-6tx9VVYFcuz4EDMmowmWUD2OrstnSe/3vcYptsiHiTa7meNNC3LBDr1z2g3KhC09TO9fgKpIekyH7OQxqZGPfQ==",
       "peerDependencies": {
-        "apache-arrow": "^14.0.x"
+        "apache-arrow": "^17.0.0"
       }
     },
     "node_modules/@observablehq/plot": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.14.tgz",
-      "integrity": "sha512-A9HWSboh1WgFonKqYKC522VkxJwhkTUTye606qjxQH8iPtSVjVXUF6JRKwf7MPaYTin/MypaSSd+08ML4LA1rw==",
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.16.tgz",
+      "integrity": "sha512-LRi9Rn93yUx90MIo2Md7+vazxO3Wiat14but2ttCER0xVS+jnfoUjuCGoz6H7bz/lgI9CFcW0HWlvWjMFjAv8g==",
       "dependencies": {
         "d3": "^7.9.0",
         "interval-tree-1d": "^1.0.0",
@@ -603,22 +604,22 @@
       ]
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
-      "integrity": "sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
+      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/command-line-args": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
-      "integrity": "sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="
     },
     "node_modules/@types/command-line-usage": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.2.tgz",
-      "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -627,93 +628,64 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
-      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ=="
+      "version": "20.17.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.5.tgz",
+      "integrity": "sha512-n8FYY/pRxu496441gIcAQFZPKXbhsd6VZygcq+PTSZ75eMh/Ke0hCAROdUa21qiFqKNsPPYic46yXDO1JGiPBQ==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
-    "node_modules/@types/pad-left": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/pad-left/-/pad-left-2.1.1.tgz",
-      "integrity": "sha512-Xd22WCRBydkGSApl5Bw0PhAOHKSVjNL3E3AwzKaps96IMraPqy5BvZIsBVK6JLwdybUzjHnuWVwpDd0JjTfHXA=="
+    "node_modules/@uwdata/flechette": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@uwdata/flechette/-/flechette-1.1.0.tgz",
+      "integrity": "sha512-UG25ytXRsElGDSIsvCuEUUkX/XImdKe7jnZF2Y5Q9uYYQH6WO60F7yLJ/sNRBJqHdn4A0QhTAOuOJevDZZcF8Q=="
     },
     "node_modules/@uwdata/mosaic-core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@uwdata/mosaic-core/-/mosaic-core-0.7.0.tgz",
-      "integrity": "sha512-lttgf9g7L8zXQxuGRJz9Y8+bPiNR7rG+YcubKFOF4CC5yBXzoo6cYDlTdKo9y0gLzxQoaxaiZ7xeVSRW1PdqWA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@uwdata/mosaic-core/-/mosaic-core-0.11.0.tgz",
+      "integrity": "sha512-0bW7zl90EXqZoUfIJCrytjeY5KNjZWoYN1of1M0fJ0A+7cxlh08iLTi9XRaptPmL6teIOpOthVV747422BYVcQ==",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "^1.28.1-dev109.0",
-        "@uwdata/mosaic-sql": "^0.7.0",
-        "apache-arrow": "^15.0.0"
-      }
-    },
-    "node_modules/@uwdata/mosaic-core/node_modules/@types/command-line-args": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
-      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="
-    },
-    "node_modules/@uwdata/mosaic-core/node_modules/@types/node": {
-      "version": "20.11.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
-      "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@uwdata/mosaic-core/node_modules/apache-arrow": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-15.0.1.tgz",
-      "integrity": "sha512-d2vb9LJFfVoWJqsQFxhXrrIwqqR+6T1m7+t7MVTC9Hth1Z0+IGa8EA9Bfv9M4L1Ttr0bjfvl5+d9LwZK6VYvaQ==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.2",
-        "@types/command-line-args": "^5.2.1",
-        "@types/command-line-usage": "^5.0.2",
-        "@types/node": "^20.6.0",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.1",
-        "flatbuffers": "^23.5.26",
-        "json-bignum": "^0.0.3",
-        "tslib": "^2.6.2"
-      },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.cjs"
+        "@duckdb/duckdb-wasm": "^1.28.1-dev278.0",
+        "@uwdata/flechette": "^1.0.2",
+        "@uwdata/mosaic-sql": "^0.11.0"
       }
     },
     "node_modules/@uwdata/mosaic-inputs": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@uwdata/mosaic-inputs/-/mosaic-inputs-0.7.0.tgz",
-      "integrity": "sha512-la1Yf6Nn6J1gHXeWfmWtkHwPhog5Su9hFwTLgac9T0xwXtK3Q2oLlNImzHOj/sdPTPPxV6cYNqjKdBUcsdl3VA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@uwdata/mosaic-inputs/-/mosaic-inputs-0.11.0.tgz",
+      "integrity": "sha512-Ilj8ZrGejddNzF39pU5kM/y6liyhfoJwDf/2jErj3rsDzMedfqSZNmQR4ftBGGj9w3Q1mfZ1tRxXwgSUzSjpOg==",
       "dependencies": {
-        "@uwdata/mosaic-core": "^0.7.0",
-        "@uwdata/mosaic-sql": "^0.7.0",
+        "@uwdata/mosaic-core": "^0.11.0",
+        "@uwdata/mosaic-sql": "^0.11.0",
         "isoformat": "^0.2.1"
       }
     },
     "node_modules/@uwdata/mosaic-plot": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@uwdata/mosaic-plot/-/mosaic-plot-0.7.0.tgz",
-      "integrity": "sha512-QA6/3mWlmdEj5ulPzgMUtYdErLgDSDU6+hOI/e1I7R5RJp07HTncvZaXUTVwBv9gnp/4zZKJBZBjYg0zwag9Mg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@uwdata/mosaic-plot/-/mosaic-plot-0.11.0.tgz",
+      "integrity": "sha512-WcIvrHqg5brlT8SPV3qFNsjaRI14govLsMrrmjTRA/uofb6kRmvFiNbNn/9+7VRReGzeB0wMiX2bvAriRAdIzA==",
       "dependencies": {
-        "@observablehq/plot": "^0.6.13",
-        "@uwdata/mosaic-core": "^0.7.0",
-        "@uwdata/mosaic-sql": "^0.7.0",
-        "d3": "^7.8.5",
+        "@observablehq/plot": "^0.6.16",
+        "@uwdata/mosaic-core": "^0.11.0",
+        "@uwdata/mosaic-sql": "^0.11.0",
+        "d3": "^7.9.0",
         "isoformat": "^0.2.1"
       }
     },
     "node_modules/@uwdata/mosaic-sql": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@uwdata/mosaic-sql/-/mosaic-sql-0.7.0.tgz",
-      "integrity": "sha512-bMnX+INlxPxGJK5tsPl/GILEyuhwTCMKpBQIHfYVStj8fAKn9KNmTTBX6YtTQdqBWrLhz73oY76/UBAuLqqwig=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@uwdata/mosaic-sql/-/mosaic-sql-0.11.0.tgz",
+      "integrity": "sha512-q2uDGxsfhhXkJYo1CXyo0RdyWsYUsHrwe+9FORfyGuxfU4+0KxhFRQn5njQm4hEejQhGoqvPbvcQxR9g6PnS+w=="
     },
     "node_modules/@uwdata/vgplot": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@uwdata/vgplot/-/vgplot-0.7.0.tgz",
-      "integrity": "sha512-o7IfJ9pqEj/CiG5q5FBo4t61RFverOnPNZ0oTlT0X9Vnf3rFhb7GvS5hmiIEiFqqpOQMWd12VB0710edT72x5w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@uwdata/vgplot/-/vgplot-0.11.0.tgz",
+      "integrity": "sha512-/7SE75UV1aNx6xMnA5m1bB0knYUdqUsxI/BQYeOZkzb3o40UGM/qMX5Fag1ystPzsVdWZBaDvIclNW2MQZ9NJw==",
       "dependencies": {
-        "@uwdata/mosaic-core": "^0.7.0",
-        "@uwdata/mosaic-inputs": "^0.7.0",
-        "@uwdata/mosaic-plot": "^0.7.0",
-        "@uwdata/mosaic-sql": "^0.7.0"
+        "@uwdata/mosaic-core": "^0.11.0",
+        "@uwdata/mosaic-inputs": "^0.11.0",
+        "@uwdata/mosaic-plot": "^0.11.0",
+        "@uwdata/mosaic-sql": "^0.11.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -731,23 +703,22 @@
       }
     },
     "node_modules/apache-arrow": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-14.0.2.tgz",
-      "integrity": "sha512-EBO2xJN36/XoY81nhLcwCJgFwkboDZeyNQ+OPsG7bCoQjc2BT0aTyH/MR6SrL+LirSNz+cYqjGRlupMMlP1aEg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
       "dependencies": {
-        "@types/command-line-args": "5.2.0",
-        "@types/command-line-usage": "5.0.2",
-        "@types/node": "20.3.0",
-        "@types/pad-left": "2.1.1",
-        "command-line-args": "5.2.1",
-        "command-line-usage": "7.0.1",
-        "flatbuffers": "23.5.26",
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
         "json-bignum": "^0.0.3",
-        "pad-left": "^2.1.0",
-        "tslib": "^2.5.3"
+        "tslib": "^2.6.2"
       },
       "bin": {
-        "arrow2csv": "bin/arrow2csv.js"
+        "arrow2csv": "bin/arrow2csv.cjs"
       }
     },
     "node_modules/array-back": {
@@ -1288,9 +1259,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "23.5.26",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
-      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ=="
+      "version": "24.3.25",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.3.25.tgz",
+      "integrity": "sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ=="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1382,17 +1353,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/pad-left": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
-      "integrity": "sha512-HJxs9K9AztdIQIAIa/OIazRAUW/L6B9hbQDxO4X07roW3eo9XqZc2ur9bn1StH9CnbbI9EgvejHQX7CBpCF1QA==",
-      "dependencies": {
-        "repeat-string": "^1.5.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -1425,14 +1385,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/robust-predicates": {
@@ -1560,9 +1512,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/vite": {
       "version": "5.1.6",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "author": "Dominik Moritz",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@motherduck/wasm-client": "^0.4.0",
-    "@uwdata/vgplot": "^0.7.0"
+    "@motherduck/wasm-client": "^0.6.0",
+    "@uwdata/flechette": "^1.1.0",
+    "@uwdata/vgplot": "^0.11.0"
   },
   "devDependencies": {
     "vite": "^5.1.6"


### PR DESCRIPTION
This is a WIP.

- example using `@motherduck/wasm-client` `0.4.0` breaks due to a network error: update to `0.6.0`
- vgplot 0.7.0 is old, update to latest 0.11.0

The 2nd part needs more work because of [v0.11.0](https://github.com/uwdata/mosaic/releases/tag/v0.11.0) move to flechette in place of apache-arrow (0.10.0 is an easy update however)

But, I get errors pointing to other basic things I need to understand. WIP

![Screenshot from 2024-11-02 21-16-18](https://github.com/user-attachments/assets/3c365e25-88de-474f-be10-06e7a32a1d6e)

Grateful for any feedback or pointers, otherwise if it's ok will post my progress bringing this up-to-date, ultimately for you to feel free to include @domoritz

Thanks for making this!